### PR TITLE
Define DevTools port dynamically

### DIFF
--- a/src/jest.setup.js
+++ b/src/jest.setup.js
@@ -31,8 +31,8 @@ beforeAll(async () => {
     if (!process.env.CI) {
         const req = got('http://localhost:9223/json')
         const pages = await req.json().catch((err) => err)
-        if (pages && pages.length) {
-            process.stdout.write(`Watch test: https://chrome-devtools-frontend.appspot.com/serve_file/@ec99b9f060de3f065f466ccd2b2bfbf17376b61e/devtools_app.html?ws=localhost:9222/devtools/page/${pages[0].id}&remoteFrontend=true\n\n`);
+        if (pages && pages.length && process.env.SAUCE_DEVTOOLS_PORT) {
+            process.stdout.write(`Watch test: https://chrome-devtools-frontend.appspot.com/serve_file/@ec99b9f060de3f065f466ccd2b2bfbf17376b61e/devtools_app.html?ws=localhost:${process.env.SAUCE_DEVTOOLS_PORT}/devtools/page/${pages[0].id}&remoteFrontend=true\n\n`);
         }
     }
 })


### PR DESCRIPTION
With https://github.com/saucelabs/saucectl-internal/pull/22 we start to define ports to connect to the DevTools interface dynamically. This port number needs to be pushed into the environment of the container to properly display the link once the connection is established.