### PR TITLE
Speed up the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ RUN curl -L -o ${SAUCECTL_BINARY} \
   && mv ./saucectl /home/seluser/bin/saucectl \
   && rm ${SAUCECTL_BINARY}
 
-COPY . .
-RUN sudo chown -R seluser /home/seluser
+COPY --chown=seluser:seluser . .
 
 #==================
 # ENTRYPOINT & CMD


### PR DESCRIPTION
Speed up the build by avoiding changing the ownership of all files in the home dir.
Most of the files are already owned by `seluser`, making this a rather expensive operation.
Instead, ownership is immediately set at the COPY statement.