### PR TITLE
fix: Ensure Puppeteer exitCode is propagated up to saucectl

### DIFF
--- a/src/jest-recorder.js
+++ b/src/jest-recorder.js
@@ -17,10 +17,10 @@ const jestRecorder = () => {
     child.stdout.pipe(ws);
     child.stderr.pipe(ws);
 
-    child.on('exit', (exitCode) => ws.end(() => {
+    child.on('exit', (exitCode) => {
         fs.closeSync(fd);
         process.exit(exitCode);
-    }));
+    });
 };
 
 exports.jestRecorder = jestRecorder;


### PR DESCRIPTION
## Proposed changes

Restore expected `exitCode` to be non-zero when some tests are failing.
Relates: https://github.com/saucelabs/testrunner-toolkit/issues/63

![render1604440567548](https://user-images.githubusercontent.com/11074879/98045138-da745600-1ddc-11eb-8e3f-5c40d1b9fc6c.gif)

### Considerations

It's not optimum since `stream.Writable` is not cleanly closed before file being closed. As soon as operations are maid on stream either `ws.end()` or waiting for `stream.finished()`, `exitCode` resets to 0 and npm is not failing as expected.

Log are still saved completely, cf. https://app.saucelabs.com/tests/ecbe89cf13ec41e989b52199f87bb4fa