### PR TITLE
Do not create job when no credentials

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -183,6 +183,10 @@ module.exports = class TestrunnerReporter {
 
     async onRunComplete (test, { testResults, numFailedTests }) {
         log.info('Finished testrun!')
+        if (process.env.SAUCE_USERNAME === '' || process.env.SAUCE_ACCESS_KEY === '') {
+            console.log('Skipping asset uploads! Remember to setup your SAUCE_USERNAME/SAUCE_ACCESS_KEY');
+            return;
+        }
         endTime = new Date().toISOString()
 
         const hasPassed = numFailedTests === 0


### PR DESCRIPTION
It should display following instead of trying to create job when no credentials set
```
Skipping asset uploads! Remember to setup your SAUCE_USERNAME/SAUCE_ACCESS_KEY
```