### PR TITLE
Use runner version in template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,9 @@ jobs:
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
           PUPPETEER_VER=`< package-lock.json  jq -r '.dependencies["puppeteer-core"].version'`
-          sed -i "s/##VERSION##/${PUPPETEER_VER}/g" .saucetpl/.sauce/config.yml
+          # Info: old version of the configuration. Until we move to native config, we need to provide
+          #       the actual docker tag instead of framework version.
+          sed -i "s/##VERSION##/${{steps.prep.outputs.version}}/g" .saucetpl/.sauce/config.yml
 
       - name: Archive template
         run: cd .saucetpl && tar -czf ../saucetpl.tar.gz .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
           cache_froms: saucelabs/stt-puppeteer-jest-node:latest
           push: false
       
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.0'
+
       # Checkout the latest saucectl
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Since Puppeteer has not moved yet to native config, the template should contains the container version/tag instead of the framework version.

A comment has been added to ensure this will be updated when moving to native configuration.

Additionnally, go updated to 1.16 to ensure e2e passes.