### PR TITLE
CI: support restarting pipeline with no side-effects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,25 +16,46 @@ jobs:
   create-release-draft:
     runs-on: ubuntu-latest
     steps:
+      - name: Check tag
+        id: prep
+        run: |
+          TAG_NAME=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name | select (. != null)")
+          IS_DRAFT=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .draft | select (. != null)")
+
+          if [ -n "${TAG_NAME}" ] && [ "${IS_DRAFT}" == "false" ];then
+              echo "A release has already been published for this run_id (${{ github.run_id }} / ${TAG_NAME})."
+              exit 1
+          fi
+          echo ::set-output name=tag_name::${TAG_NAME}
+
       - uses: actions/checkout@v2
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Setup Node version
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
       - name: Setup Git
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: |
           git config --global user.name "devx-sauce-bot"
           git config --global user.email "devx.bot@saucelabs.com"
 
       - name: Install dependencies
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: npm ci
 
       - name: generate (pre-)release draft
+        if: ${{ steps.prep.outputs.tag_name == '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -119,21 +140,30 @@ jobs:
               echo "No draft version found"
               exit 1
           fi
+
+          ASSET_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
+                      https://api.github.com/repos/${{ github.repository }}/releases | \
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .assets | .[] | select(.name == \"saucetpl.tar.gz\") | .id | select(. != null)")
+
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=release_id::${RELEASE_ID}
+          echo ::set-output name=asset_id::${ASSET_ID}
 
-      - run: echo "${{ steps.prep.outputs.release_id }} - ${{  steps.prep.outputs.version }}"
+      - run: echo "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
 
       - uses: actions/checkout@v2
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         with:
           ref: ${{ steps.prep.outputs.version }}
 
       - name: Use Node.js v14.x
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
       - name: Update Release version
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
           PUPPETEER_VER=`< package-lock.json  jq -r '.dependencies["puppeteer-core"].version'`
@@ -142,9 +172,11 @@ jobs:
           sed -i "s/##VERSION##/${{steps.prep.outputs.version}}/g" .saucetpl/.sauce/config.yml
 
       - name: Archive template
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: cd .saucetpl && tar -czf ../saucetpl.tar.gz .
 
       - name: Upload Template Asset
+        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
- Check for existing tag/release associated with current pipeline
- Avoid rebuilding templates/bundles
- Generate error if already publish

FYI: Checks failing because of cross-repo PR.