### PR TITLE
Add support for native config

### DIFF
--- a/.saucetpl/.sauce/config.yml
+++ b/.saucetpl/.sauce/config.yml
@@ -1,18 +1,21 @@
 apiVersion: v1alpha
-metadata:
-  name: Feature XYZ
-  tags:
-    - e2e
-    - release team
-    - other tag
-  build: Release $CI_COMMIT_SHORT_SHA
-files:
-  - tests/example.test.js
-suites:
-  - name: "saucy test"
-    match: ".*.(spec|test).js$"
-image:
-  base: saucelabs/stt-puppeteer-jest-node
-  version: ##VERSION##
+kind: puppeteer
 sauce:
   region: us-west-1
+  concurrency: 2
+  metadata:
+    name: Testing Puppeteer Support
+    tags:
+      - e2e
+      - release team
+      - other tag
+    build: Release $CI_COMMIT_SHORT_SHA
+rootDir: ./
+puppeteer:
+  version: 3.0.4
+suites:
+  - name: "chrome"
+    testMatch: ["**/*.test.js"]
+    browser: "chrome"
+docker:
+  image: saucelabs/stt-puppeteer-jest-node:latest

--- a/.saucetpl/.sauce/config.yml
+++ b/.saucetpl/.sauce/config.yml
@@ -17,5 +17,3 @@ suites:
   - name: "chrome"
     testMatch: ["**/*.test.js"]
     browser: "chrome"
-docker:
-  image: saucelabs/stt-puppeteer-jest-node:latest

--- a/.saucetpl/.sauceignore
+++ b/.saucetpl/.sauceignore
@@ -1,0 +1,12 @@
+# Remove this to have node_modules uploaded with code
+node_modules/
+.git/
+.github/
+.DS_Store
+.hg/
+.vscode/
+.idea/
+.gitignore
+.hgignore
+.gitlab-ci.yml
+.npmrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,12 @@ COPY --chown=seluser:seluser . .
 RUN mkdir tests/
 
 # Workaround for permissions in CI if run with a different user
-RUN chmod 777 -R /home/seluser/
+#RUN chmod 777 -R /home/seluser/
+
+# Let saucectl know where to mount files
+RUN mkdir -p /home/seluser/__project__/ && chown seluser:seluser /home/seluser/__project__/
+LABEL com.saucelabs.project-dir=/home/seluser/__project__/
+ENV SAUCE_PROJECT_DIR=/home/seluser/__project__/
 
 # Let saucectl know where to read job details url
 LABEL com.saucelabs.job-info=/tmp/output.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,6 @@ ENV IMAGE_TAG=${BUILD_TAG}
 RUN npm ci --production
 
 COPY --chown=seluser:seluser . .
-RUN mkdir tests/
-
-# Workaround for permissions in CI if run with a different user
-#RUN chmod 777 -R /home/seluser/
 
 # Let saucectl know where to mount files
 RUN mkdir -p /home/seluser/__project__/ && chown seluser:seluser /home/seluser/__project__/

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,20 +1,10 @@
 exports.HOME_DIR = process.env.TEST_HOME_DIR || '/home/seluser'
+exports.PROJECT_DIR = process.env.SAUCE_PROJECT_DIR
 exports.CHROME_DEFAULT_PATH = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
 exports.DEFAULT_JEST_TIMEOUT = 60 // 1min
 exports.COMMAND_TIMEOUT = 10 * 1000 // 10s
 
-const LOG_DIR = '/var/log/cont'
 exports.LOG_FILES = [
-    LOG_DIR + '/chrome_browser.log',
-    LOG_DIR + '/firefox_browser.log',
-    LOG_DIR + '/supervisord.log',
-    LOG_DIR + '/video-rec-stderr.log',
-    LOG_DIR + '/video-rec-stdout.log',
-    LOG_DIR + '/wait-xvfb.1.log',
-    LOG_DIR + '/wait-xvfb.2.log',
-    LOG_DIR + '/wait-xvfb-stdout.log',
-    LOG_DIR + '/xvfb-tryouts-stderr.log',
-    LOG_DIR + '/xvfb-tryouts-stdout.log',
     exports.HOME_DIR + '/videos/video.mp4',
     exports.HOME_DIR + '/docker.log',
     exports.HOME_DIR + '/console.log',

--- a/src/jest-recorder.js
+++ b/src/jest-recorder.js
@@ -4,13 +4,26 @@ const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
 const child_process = require('child_process');
+const {ASSETS_DIR} = require("./constants");
+const {getArgs, loadRunConfig, getAbsolutePath} = require('sauce-testrunner-utils');
 
-const jestRecorder = () => {
+const jestRecorder = async () => {
     const fd = fs.openSync(path.join(__dirname, '..', 'console.log'), 'w+', 0o644);
     const ws = stream.Writable({
-        write (data, encoding, cb) { fs.write(fd, data, undefined, encoding, cb) },
+        write(data, encoding, cb) {
+            fs.write(fd, data, undefined, encoding, cb)
+        },
     });
-    const child = child_process.spawn('jest', ['--no-colors', ...process.argv.slice(2)]);
+
+    const {runCfgPath, suiteName} = getArgs();
+    const runCfgAbsolutePath = getAbsolutePath(runCfgPath);
+    const runCfg = await loadRunConfig(runCfgAbsolutePath);
+    runCfg.path = runCfgPath;
+    process.env['SAUCE_RUNNER_CONFIG'] = runCfgPath
+    process.env['SAUCE_SUITE'] = suiteName
+
+    const child = child_process.spawn('jest', ['--no-colors',
+        '--config=./.config/jest.config.js', '--runInBand', '--forceExit']);
 
     child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stderr);

--- a/src/jest.setup.js
+++ b/src/jest.setup.js
@@ -1,6 +1,5 @@
 const path = require('path')
 
-const got = require('got')
 const puppeteer = require('puppeteer-core')
 const debug = require(
     path.join(
@@ -24,17 +23,6 @@ beforeAll(async () => {
         args: CHROME_ARGS,
         executablePath: process.env.CHROME_BINARY_PATH || CHROME_DEFAULT_PATH
     })
-
-    /**
-     * show debug link only in CI
-     */
-    if (!process.env.CI) {
-        const req = got('http://localhost:9223/json')
-        const pages = await req.json().catch((err) => err)
-        if (pages && pages.length && process.env.SAUCE_DEVTOOLS_PORT) {
-            process.stdout.write(`Watch test: https://chrome-devtools-frontend.appspot.com/serve_file/@ec99b9f060de3f065f466ccd2b2bfbf17376b61e/devtools_app.html?ws=localhost:${process.env.SAUCE_DEVTOOLS_PORT}/devtools/page/${pages[0].id}&remoteFrontend=true\n\n`);
-        }
-    }
 })
 
 const monkeyPatchedTest = (origFn) => (testName, testFn) => {


### PR DESCRIPTION
Add support for the new native config.

Corresponding saucectl change: https://github.com/saucelabs/saucectl/pull/252

Suggest config layout:

```yaml
apiVersion: v1alpha
kind: puppeteer
sauce:
  region: us-west-1
  metadata:
    name: Testing Puppeteer Support
    tags:
      - e2e
      - release team
      - other tag
    build: Release $CI_COMMIT_SHORT_SHA
rootDir: tests/e2e/puppeteer
puppeteer:
  version: 3.0.4
suites:
  - name: "chrome"
    testMatch: ["**/example.test.js"]
    browser: "chrome"
docker:
  image: saucelabs/stt-puppeteer-jest-node:latest
```

**What's missing? (will be tackled in separate PRs)**
- test artifacts (aka assets) are still all over the place and not in a dedicated folder
- base docker image is still old
- supports only chrome (firefox should be doable)