### PR TITLE
Update base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM saucelabs/testrunner-image:v0.1.1
+FROM saucelabs/testrunner-image:v0.2.0
 
 #================
 # Install Node.JS


### PR DESCRIPTION
Update base image version to https://github.com/saucelabs/testrunner-image/releases/tag/v0.2.0.
This update includes new browser versions.