### PR TITLE
Switch to dynamic version templating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,9 +167,7 @@ jobs:
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
           PUPPETEER_VER=`< package-lock.json  jq -r '.dependencies["puppeteer-core"].version'`
-          # Info: old version of the configuration. Until we move to native config, we need to provide
-          #       the actual docker tag instead of framework version.
-          sed -i "s/##VERSION##/${{steps.prep.outputs.version}}/g" .saucetpl/.sauce/config.yml
+          sed -i "s/##VERSION##/${PUPPETEER_VER}/g" .saucetpl/.sauce/config.yml
 
       - name: Archive template
         if: ${{ steps.prep.outputs.asset_id == '' }}

--- a/.saucetpl/.sauce/config.yml
+++ b/.saucetpl/.sauce/config.yml
@@ -12,7 +12,7 @@ sauce:
     build: Release $CI_COMMIT_SHORT_SHA
 rootDir: ./
 puppeteer:
-  version: 8.0.0
+  version: ##VERSION##
 suites:
   - name: "chrome"
     testMatch: ["**/*.test.js"]


### PR DESCRIPTION
With the native config support, we can now switch to the dynamic version templating that is based on the underlying framework version (we do the same for cypress/playwright/testcafe already).